### PR TITLE
style: pie chart 커스텀

### DIFF
--- a/src/components/charts/pie-chart/ScorePieChart.stories.tsx
+++ b/src/components/charts/pie-chart/ScorePieChart.stories.tsx
@@ -1,0 +1,26 @@
+import { Meta, StoryObj } from '@storybook/react';
+import ScorePieChart from '@chart/pie-chart/ScorePieChart';
+
+const meta: Meta = {
+  title: 'chart/pieChart',
+  component: ScorePieChart,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ScorePieChart>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const dummyData = [
+  { name: '시설 점수', value: 45 },
+  { name: '관리 점수', value: 80 },
+  { name: '민원 점수', value: 30 },
+];
+
+export const PieChartCustom: Story = {
+  render: args => <ScorePieChart scoreData={dummyData} />,
+  args: {},
+};

--- a/src/components/charts/pie-chart/ScorePieChart.tsx
+++ b/src/components/charts/pie-chart/ScorePieChart.tsx
@@ -3,15 +3,18 @@
 import React, { useCallback, useState } from 'react';
 import { Cell, PieChart, Pie, ResponsiveContainer, Sector } from 'recharts';
 
-const dummyData = [
-  { name: '시설 점수', value: 45 },
-  { name: '관리 점수', value: 80 },
-  { name: '민원 점수', value: 30 },
-];
+interface ScorePieChartData {
+  name?: string;
+  value: number;
+}
+
+export interface ScorePieChartProps {
+  scoreData: ScorePieChartData[];
+}
 
 const COLORS = ['#2563EB', '#7DCB70', '#F3B570'];
 
-export default function ScorePieChart() {
+export default function ScorePieChart({ scoreData }: ScorePieChartProps) {
   const [activeIndex, setActiveIndex] = useState(1);
   const onPieEnter = useCallback(
     (_: unknown, index: number) => {
@@ -31,7 +34,7 @@ export default function ScorePieChart() {
             activeIndex={activeIndex}
             activeShape={PieActiveShape}
             paddingAngle={5}
-            data={dummyData}
+            data={scoreData}
             cx="50%"
             cy="50%"
             innerRadius={55}
@@ -40,7 +43,7 @@ export default function ScorePieChart() {
             labelLine={PieTextCustomizedLabelLine}
             label={PieTextCustomizedLabel}
             onMouseEnter={onPieEnter}>
-            {dummyData.map((_, index) => (
+            {scoreData?.map((_: unknown, index: number) => (
               <Cell
                 key={`cell-${index}`}
                 fill={COLORS[index % COLORS.length]}

--- a/src/components/charts/pie-chart/ScorePieChart.tsx
+++ b/src/components/charts/pie-chart/ScorePieChart.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import { Cell, PieChart, Pie, ResponsiveContainer, Sector } from 'recharts';
+
+const dummyData = [
+  { name: '시설 점수', value: 45 },
+  { name: '관리 점수', value: 80 },
+  { name: '민원 점수', value: 30 },
+];
+
+const COLORS = ['#2563EB', '#7DCB70', '#F3B570'];
+
+export default function ScorePieChart() {
+  const [activeIndex, setActiveIndex] = useState(1);
+  const onPieEnter = useCallback(
+    (_: unknown, index: number) => {
+      setActiveIndex(index);
+    },
+    [setActiveIndex],
+  );
+  return (
+    <div className="h-[144px] w-[144px]">
+      <ResponsiveContainer
+        width="100%"
+        height="100%">
+        {/* FIXME: pieChart overflow 타입 에러 */}
+        {/* @ts-ignore */}
+        <PieChart overflow="visible">
+          <Pie
+            activeIndex={activeIndex}
+            activeShape={PieActiveShape}
+            paddingAngle={5}
+            data={dummyData}
+            cx="50%"
+            cy="50%"
+            innerRadius={55}
+            outerRadius={80}
+            dataKey="value"
+            labelLine={PieTextCustomizedLabelLine}
+            label={PieTextCustomizedLabel}
+            onMouseEnter={onPieEnter}>
+            {dummyData.map((_, index) => (
+              <Cell
+                key={`cell-${index}`}
+                fill={COLORS[index % COLORS.length]}
+              />
+            ))}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+interface CustomCommonProps {
+  cx: number;
+  cy: number;
+  midAngle: number;
+  outerRadius: number;
+}
+
+interface PieTextCustomizedLabelProps extends CustomCommonProps {
+  value: number;
+  name: string;
+}
+
+const RADIAN = Math.PI / 180;
+const PieActiveShape = ({ ...props }) => {
+  const { cx, cy, innerRadius, outerRadius, startAngle, endAngle, fill } = props;
+
+  return (
+    <g>
+      <Sector
+        cx={cx}
+        cy={cy}
+        innerRadius={innerRadius}
+        outerRadius={outerRadius}
+        startAngle={startAngle}
+        endAngle={endAngle}
+        fill={fill}
+      />
+      <Sector
+        cx={cx}
+        cy={cy}
+        startAngle={startAngle}
+        endAngle={endAngle}
+        innerRadius={outerRadius - 1}
+        outerRadius={outerRadius + 10}
+        fill={fill}
+      />
+    </g>
+  );
+};
+
+const PieTextCustomizedLabel = (props: PieTextCustomizedLabelProps) => {
+  const { cx, cy, midAngle, outerRadius, value, name } = props;
+
+  const RADIAN = Math.PI / 180;
+
+  const sin = Math.sin(-RADIAN * midAngle);
+  const cos = Math.cos(-RADIAN * midAngle);
+  const mx = cx + (outerRadius + 30) * cos;
+  const my = cy + (outerRadius + 30) * sin;
+  const ex = mx + (cos >= 0 ? 1 : -1) * 18;
+  const ey = my;
+  const textAnchor = cos >= 0 ? 'start' : 'end';
+
+  return (
+    <g>
+      <text
+        x={ex + (cos >= 0 ? -12 : 12)}
+        y={ey}
+        textAnchor={textAnchor}
+        fill="#111827"
+        className="text-body4">
+        {`${name}`}
+      </text>
+      <text
+        x={ex + (cos >= 0 ? -2 : 3)}
+        y={ey + 7}
+        dy={18}
+        textAnchor={textAnchor}
+        fill="#111827"
+        className="text-h4">
+        {value}점
+      </text>
+    </g>
+  );
+};
+
+const PieTextCustomizedLabelLine = (props: CustomCommonProps) => {
+  const { cx, cy, midAngle, outerRadius } = props;
+
+  const sin = Math.sin(-RADIAN * midAngle);
+  const cos = Math.cos(-RADIAN * midAngle);
+  const sx = cx + (outerRadius - 10) * cos;
+  const sy = cy + (outerRadius - 10) * sin;
+  const mx = cx + (outerRadius + 30) * cos;
+  const my = cy + (outerRadius + 30) * sin;
+  const ey = my;
+  return (
+    <g>
+      <path
+        d={`M${sx},${sy}L${mx},${my}L${ey}`}
+        stroke={'#D1D5DB'}
+        stroke-width="2"
+        fill="none"
+      />
+      <circle
+        cx={sx}
+        cy={sy}
+        r={3}
+        fill={'#D1D5DB'}
+        stroke="none"
+      />
+    </g>
+  );
+};


### PR DESCRIPTION
## 🧾 관련 이슈
close : #32


## 🔎 구현한 내용
pie chart 커스텀 진행했습니다!
🔗 [스토리북 배포 링크](https://66421fd64f35d30603e16002-lrjdxhlbhe.chromatic.com/?path=/story/chart-piechart--pie-chart-custom)

## 📸 스크린샷(선택사항)
<img width="400" alt="image" src="https://github.com/KPT-Final-Team9/front/assets/104605709/357e7f8c-1f76-48c4-b74f-788f9394dfe2">


## 🙌 리뷰어에게
- 바로 해결하지 못한 props 타입 에러 2개가 존재합니다. 임시방편으로 `// @ts-ignore` 사용 및 `...props`으로 해결해둔 상태입니다.

