### PR TITLE
feat: 내호실 평가 관리 섹션 구현

### DIFF
--- a/src/app/(after-login)/room/@RatingManagement/_component/RatingManagementClientComp.tsx
+++ b/src/app/(after-login)/room/@RatingManagement/_component/RatingManagementClientComp.tsx
@@ -1,0 +1,6 @@
+'use client';
+import React from 'react';
+
+export default function RatingManagementClientComp() {
+  return <div>RatingManagementClientComp</div>;
+}

--- a/src/app/(after-login)/room/@RatingManagement/_component/RatingManagementClientComp.tsx
+++ b/src/app/(after-login)/room/@RatingManagement/_component/RatingManagementClientComp.tsx
@@ -1,8 +1,24 @@
 'use client';
 import ReviewTrackProgress from '@Monocles/progress-bar/ReviewTrackProgress';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+
+const MOCK_RATING_PROGRESS_VALUE = 85;
 
 export default function RatingManagementClientComp() {
+  const [isRatingActive, setIsRatingActive] = useState<boolean>(true);
+  const [ratingProgressValue, setRatingPrgressValue] = useState<number | undefined>(undefined);
+
+  const handleRatingActiveChange = () => {
+    setIsRatingActive(prev => !prev);
+    if (window) window.alert('호실 평가 변경됨');
+  };
+
+  useEffect(() => {
+    setTimeout(() => {
+      setRatingPrgressValue(MOCK_RATING_PROGRESS_VALUE);
+    }, 100);
+  }, []);
+
   return (
     <div>
       <div className="mb-6 flex gap-4 desktop:mb-9 desktop:gap-9">
@@ -15,7 +31,7 @@ export default function RatingManagementClientComp() {
       <div className="flex flex-col">
         <p className="mb-2 text-body4">평가 진행률</p>
         <ReviewTrackProgress
-          value={40}
+          value={ratingProgressValue}
           trackFontClass="desktop:text-caption"
           legendClass="mt-2"
         />

--- a/src/app/(after-login)/room/@RatingManagement/_component/RatingManagementClientComp.tsx
+++ b/src/app/(after-login)/room/@RatingManagement/_component/RatingManagementClientComp.tsx
@@ -1,6 +1,25 @@
 'use client';
+import ReviewTrackProgress from '@Monocles/progress-bar/ReviewTrackProgress';
 import React from 'react';
 
 export default function RatingManagementClientComp() {
-  return <div>RatingManagementClientComp</div>;
+  return (
+    <div>
+      <div className="mb-6 flex gap-4 desktop:mb-9 desktop:gap-9">
+        <div>
+          <div className="text-body4 text-text-primary">내호실 평가받기 설정</div>
+          <span className="text-overline text-text-secondary">내호실의 평가 내용을 요약하여 받아볼 수 있어요</span>
+        </div>
+        <div>스위치</div>
+      </div>
+      <div className="flex flex-col">
+        <p className="mb-2 text-body4">평가 진행률</p>
+        <ReviewTrackProgress
+          value={40}
+          trackFontClass="desktop:text-caption"
+          legendClass="mt-2"
+        />
+      </div>
+    </div>
+  );
 }

--- a/src/app/(after-login)/room/@RatingManagement/_component/RatingManagementClientComp.tsx
+++ b/src/app/(after-login)/room/@RatingManagement/_component/RatingManagementClientComp.tsx
@@ -1,4 +1,5 @@
 'use client';
+import ToggleSwitch from '@Atoms/switch/ToggleSwitch';
 import ReviewTrackProgress from '@Monocles/progress-bar/ReviewTrackProgress';
 import React, { useEffect, useState } from 'react';
 
@@ -26,7 +27,12 @@ export default function RatingManagementClientComp() {
           <div className="text-body4 text-text-primary">내호실 평가받기 설정</div>
           <span className="text-overline text-text-secondary">내호실의 평가 내용을 요약하여 받아볼 수 있어요</span>
         </div>
-        <div>스위치</div>
+        <div>
+          <ToggleSwitch
+            isActive={isRatingActive}
+            handleToggleChange={handleRatingActiveChange}
+          />
+        </div>
       </div>
       <div className="flex flex-col">
         <p className="mb-2 text-body4">평가 진행률</p>

--- a/src/app/(after-login)/room/@RatingManagement/_component/RatingManagementServerComp.tsx
+++ b/src/app/(after-login)/room/@RatingManagement/_component/RatingManagementServerComp.tsx
@@ -3,8 +3,8 @@ import RatingManagementClientComp from './RatingManagementClientComp';
 
 export default function RatingManagementServerComp() {
   return (
-    <div className="h-[222px] w-[343px] rounded-container bg-white desktop:h-[282px] desktop:w-[394px]">
-      RatingManagementServerComp
+    <div className="h-[222px] w-[343px] rounded-container bg-white px-6 py-4 desktop:h-[282px] desktop:w-[394px] desktop:px-10 desktop:py-8">
+      <h4 className="mb-8 text-h4 desktop:mb-10">내호실 평가 관리</h4>
       <RatingManagementClientComp />
     </div>
   );

--- a/src/app/(after-login)/room/@RatingManagement/_component/RatingManagementServerComp.tsx
+++ b/src/app/(after-login)/room/@RatingManagement/_component/RatingManagementServerComp.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import RatingManagementClientComp from './RatingManagementClientComp';
+
+export default function RatingManagementServerComp() {
+  return (
+    <div className="h-[222px] w-[343px] rounded-container bg-white desktop:h-[282px] desktop:w-[394px]">
+      RatingManagementServerComp
+      <RatingManagementClientComp />
+    </div>
+  );
+}

--- a/src/app/(after-login)/room/@RatingManagement/page.tsx
+++ b/src/app/(after-login)/room/@RatingManagement/page.tsx
@@ -1,3 +1,9 @@
+import RatingManagementServerComp from './_component/RatingManagementServerComp';
+
 export default function Page() {
-  return <>내호실 평가 관리</>;
+  return (
+    <>
+      <RatingManagementServerComp />
+    </>
+  );
 }

--- a/src/app/(after-login)/room/layout.tsx
+++ b/src/app/(after-login)/room/layout.tsx
@@ -12,11 +12,11 @@ export default function Layout({
   RatingTrend: React.ReactNode;
 }) {
   return (
-    <main className="flex flex-col gap-3 p-5">
+    <main className="flex flex-col gap-8 p-5">
       <section className="bg-background">{Overview}</section>
       <section className="flex gap-3">
-        <div className="bg-background">{CategoryRating}</div>
         <div className="bg-background">{RatingManagement}</div>
+        <div className="bg-background">{CategoryRating}</div>
       </section>
       <section className="bg-background">{RatingTrend}</section>
     </main>

--- a/src/components/common/Monocles/progress-bar/ReviewTrackProgress.tsx
+++ b/src/components/common/Monocles/progress-bar/ReviewTrackProgress.tsx
@@ -26,9 +26,11 @@ const ReviewTrackRank: { [key: string]: ProgressStep } = {
 export default function ReviewTrackProgress({
   value,
   trackFontClass,
+  legendClass,
 }: {
   value: number;
   trackFontClass?: 'desktop:text-body4' | 'desktop:text-caption';
+  legendClass?: string;
 }) {
   const reviewTrackFontClass = cn('text-caption', trackFontClass);
   return (
@@ -38,7 +40,7 @@ export default function ReviewTrackProgress({
         className="h-[13px]"
         indicatorColor="evaluation-gradient"
       />
-      <div className="mt-[12px] flex justify-center">
+      <div className={cn('mt-[12px] flex justify-center', legendClass)}>
         <div className="flex flex-row gap-3 self-center">
           {Object.keys(ReviewTrackRank).map((val, index) => {
             return (

--- a/src/components/common/Monocles/progress-bar/ReviewTrackProgress.tsx
+++ b/src/components/common/Monocles/progress-bar/ReviewTrackProgress.tsx
@@ -23,6 +23,21 @@ const ReviewTrackRank: { [key: string]: ProgressStep } = {
   },
 };
 
+// 평가 진행율을 이후 변경될 수 있는 값을 기준으로 3단계로 구분되며 정확한 수치는 보여지지 않음.
+type ReviewProgressGrade = 'FIRST_STEP' | 'SECOND_STEP' | 'THIRD_STEP';
+enum ReviewProgressGradeCriteria {
+  // 단계별 기준이 되는 수치가 변경될 경우 여기에서 수정하면 됨.
+  FIRST_STEP = 33.4,
+  SECOND_STEP = 66.7,
+  THIRD_STEP = 100,
+}
+
+const getGradeFromValue = (value: number): ReviewProgressGrade => {
+  if (value >= ReviewProgressGradeCriteria.SECOND_STEP) return 'THIRD_STEP';
+  if (value >= ReviewProgressGradeCriteria.FIRST_STEP) return 'SECOND_STEP';
+  return 'FIRST_STEP';
+};
+
 export default function ReviewTrackProgress({
   value,
   trackFontClass,
@@ -33,10 +48,12 @@ export default function ReviewTrackProgress({
   legendClass?: string;
 }) {
   const reviewTrackFontClass = cn('text-caption', trackFontClass);
+  const progressGrade: ReviewProgressGrade = getGradeFromValue(value);
+
   return (
     <>
       <ReverseProgress
-        value={value}
+        value={ReviewProgressGradeCriteria[progressGrade]}
         className="h-[13px]"
         indicatorColor="evaluation-gradient"
       />

--- a/src/components/common/Monocles/progress-bar/ReviewTrackProgress.tsx
+++ b/src/components/common/Monocles/progress-bar/ReviewTrackProgress.tsx
@@ -24,15 +24,20 @@ const ReviewTrackRank: { [key: string]: ProgressStep } = {
 };
 
 // 평가 진행율을 이후 변경될 수 있는 값을 기준으로 3단계로 구분되며 정확한 수치는 보여지지 않음.
-type ReviewProgressGrade = 'FIRST_STEP' | 'SECOND_STEP' | 'THIRD_STEP';
+type ReviewProgressGrade = 'ZERO' | 'FIRST_STEP' | 'SECOND_STEP' | 'THIRD_STEP';
 enum ReviewProgressGradeCriteria {
   // 단계별 기준이 되는 수치가 변경될 경우 여기에서 수정하면 됨.
+  ZERO = 0,
   FIRST_STEP = 33.4,
   SECOND_STEP = 66.7,
   THIRD_STEP = 100,
 }
 
-const getGradeFromValue = (value: number): ReviewProgressGrade => {
+const getGradeFromValue = (value: number | undefined): ReviewProgressGrade => {
+  // 값이 undefined일 때만 ZERO를 반환. 실제로 값이 0이라면 FIRST_STEP이 됨.
+  // 값을 받아오는 중이거나 에러로 서버에서 값을 받아오지 못한 경우와, 실제 값이 0인 경우를 구분하기 위함.
+  if (value === undefined) return 'ZERO';
+
   if (value >= ReviewProgressGradeCriteria.SECOND_STEP) return 'THIRD_STEP';
   if (value >= ReviewProgressGradeCriteria.FIRST_STEP) return 'SECOND_STEP';
   return 'FIRST_STEP';
@@ -43,7 +48,7 @@ export default function ReviewTrackProgress({
   trackFontClass,
   legendClass,
 }: {
-  value: number;
+  value: number | undefined;
   trackFontClass?: 'desktop:text-body4' | 'desktop:text-caption';
   legendClass?: string;
 }) {


### PR DESCRIPTION
## 🧾 관련 이슈
close : #53 

## 🔎 구현한 내용
1. 내 호실 평가 관리 섹션 구현
<img width="413" alt="image" src="https://github.com/KPT-Final-Team9/front/assets/69471032/ceea93cc-8df7-45ac-9202-dd248bb0ec45">

2. 평가 진행률 바, 구체적인 수치를 3단계로 나눠서 보여주는 로직추가
```tsx
// 평가 진행율을 이후 변경될 수 있는 값을 기준으로 3단계로 구분되며 정확한 수치는 보여지지 않음.
type ReviewProgressGrade = 'ZERO' | 'FIRST_STEP' | 'SECOND_STEP' | 'THIRD_STEP';
enum ReviewProgressGradeCriteria {
  // 단계별 기준이 되는 수치가 변경될 경우 여기에서 수정하면 됨.
  ZERO = 0,
  FIRST_STEP = 33.4,
  SECOND_STEP = 66.7,
  THIRD_STEP = 100,
}

const getGradeFromValue = (value: number | undefined): ReviewProgressGrade => {
  // 값이 undefined일 때만 ZERO를 반환. 실제로 값이 0이라면 FIRST_STEP이 됨.
  // 값을 받아오는 중이거나 에러로 서버에서 값을 받아오지 못한 경우와, 실제 값이 0인 경우를 구분하기 위함.
  if (value === undefined) return 'ZERO';

  if (value >= ReviewProgressGradeCriteria.SECOND_STEP) return 'THIRD_STEP';
  if (value >= ReviewProgressGradeCriteria.FIRST_STEP) return 'SECOND_STEP';
  return 'FIRST_STEP';
};

...

const progressGrade: ReviewProgressGrade = getGradeFromValue(value);

...
  <ReverseProgress
    value={ReviewProgressGradeCriteria[progressGrade]}
    className="h-[13px]"
    indicatorColor="evaluation-gradient"
  />
```

## 🙌 리뷰어에게
ReviewTrackProgress에 구체적인 수치가 아닌, 3단계로 나누어서 보여주는 로직을 추가하였습니다.
