### PR TITLE
fix: 호실별 페이지 레이아웃 깨지는 버그 수정

### DIFF
--- a/src/app/(after-login)/room/@Overview/_component/ContractInfoServerComp.tsx
+++ b/src/app/(after-login)/room/@Overview/_component/ContractInfoServerComp.tsx
@@ -4,7 +4,7 @@ import ContractEditDialog from './ContractEditDialog';
 
 export default function ContractInfoServerComp() {
   return (
-    <div className="flex h-[262px] w-full flex-col gap-1 rounded-container bg-primary px-6 py-4 desktop:h-[262px] desktop:w-[264px]">
+    <div className="flex min-h-[262px] w-full flex-col gap-1 rounded-container bg-primary px-6 py-4 desktop:min-h-[262px] desktop:w-[264px]">
       <div className="flex justify-between">
         <h4 className="text-h4 text-white">계약 정보</h4>
         <ContractEditDialog />

--- a/src/app/(after-login)/room/@RatingManagement/_component/RatingManagementServerComp.tsx
+++ b/src/app/(after-login)/room/@RatingManagement/_component/RatingManagementServerComp.tsx
@@ -3,7 +3,7 @@ import RatingManagementClientComp from './RatingManagementClientComp';
 
 export default function RatingManagementServerComp() {
   return (
-    <div className="  rounded-container bg-white px-6 py-4 desktop:h-[282px] desktop:w-[394px] desktop:px-10 desktop:py-8">
+    <div className="min-h-[222px] rounded-container bg-white px-6 py-4 desktop:min-h-[282px] desktop:w-[394px] desktop:px-10 desktop:py-8">
       <h4 className="mb-8 text-h4 desktop:mb-10">내호실 평가 관리</h4>
       <RatingManagementClientComp />
     </div>


### PR DESCRIPTION
## 🧾 관련 이슈
close : #83


## 🔎 구현한 내용
- 내호실 평가 관리 레이아웃 깨지는 버그 수정
- 계약 정보 레이아웃 깨지는 버그 수정


## 📸 스크린샷(선택사항)



## 🙌 리뷰어에게


